### PR TITLE
Feature/download multiple qr img at once

### DIFF
--- a/qrcode/bulk_action.php
+++ b/qrcode/bulk_action.php
@@ -1,0 +1,50 @@
+<?php
+/**
+* PHP Dynamic Qr code
+*
+* @author    Giandonato Inverso <info@giandonatoinverso.it>
+* @copyright Copyright (c) 2020-2021
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://github.com/giandonatoinverso/PHP-Dynamic-Qr-code
+* @version   1.0
+*/
+
+session_start();
+require_once 'config/config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $db = getDbInstance();
+    $json = json_decode(file_get_contents('php://input'), true);
+    $action = filter_var($json['action'], FILTER_SANITIZE_STRING);
+    $params = $json['params'];
+    $files = [];
+    $type = filter_var($json['type'], FILTER_SANITIZE_STRING);
+
+    foreach ($params as $param) {
+        $row = $db->where('id', $param);
+        $row = $db->getOne("{$type}_qrcodes");
+        $files[] = './saved_qrcode/' . $row['qrcode'];
+    }
+
+    $zip = new ZipArchive();
+    $relative_dir = './saved_qrcode/zip/qrcodes_'. $_SESSION['user_id'] .'.zip';
+    unlink($relative_dir);
+    $url_path = base_url() . '/saved_qrcode/zip/qrcodes_'. $_SESSION['user_id'] .'.zip';
+    $zip->open($relative_dir, ZipArchive::CREATE);
+
+    foreach ($files as $file) {
+        $download_file = file_get_contents($file, true);
+        $zip->addFromString(basename($file), $download_file);
+    }
+
+    $zip->close();
+    
+    echo json_encode([
+        'data' => $url_path,
+        'status' => 200
+    ]);
+    exit();
+} else {
+    exit('Direct access to this script not allowed.');
+}
+?>

--- a/qrcode/dist/css/custom.css
+++ b/qrcode/dist/css/custom.css
@@ -7,3 +7,7 @@
 * @link      https://github.com/giandonatoinverso/PHP-Dynamic-Qr-code
 * @version   1.0
 */
+
+.bulk-action-wrapper {
+    padding: 10px 0;
+}

--- a/qrcode/dist/css/custom.css
+++ b/qrcode/dist/css/custom.css
@@ -1,0 +1,9 @@
+/**
+* PHP Dynamic Qr code
+*
+* @author    Giandonato Inverso <info@giandonatoinverso.it>
+* @copyright Copyright (c) 2020-2021
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://github.com/giandonatoinverso/PHP-Dynamic-Qr-code
+* @version   1.0
+*/

--- a/qrcode/dist/js/custom.js
+++ b/qrcode/dist/js/custom.js
@@ -421,4 +421,59 @@
     $('.product-image-thumb.active').removeClass('active');
     $(this).addClass('active');
   });
+
+  const bulk_action = $('input[name=bulk-select]');
+
+  if (bulk_action) {
+    bulk_action.on('change', function() {
+      if ($(this).prop('checked')) {
+        $('input[name^=action]').each(function() {
+          $(this).prop('checked', true);
+        });
+      } else {
+        $('input[name^=action]').each(function() {
+          $(this).prop('checked', false);
+        });
+      }
+    });
+  }
+
+  const bulk_form = $('form#bulk-action');
+
+  bulk_form.on('submit', function(e) {
+    e.preventDefault();
+    const paramsElements = document.querySelectorAll('input[name^=action]');
+    console.log(paramsElements);
+    let params = [];
+
+    paramsElements.forEach((val) => {
+      if (val.checked) {
+        params.push(val.value);
+      }
+    });
+
+    const data = {
+      action: $('select[name=bulk-action]').val(),
+      params: params,
+      type: $('input[name=type]').val()
+    }
+
+    $.ajax({
+      url: window.location.origin + '/bulk_action.php',
+      method: "POST",
+      data: JSON.stringify(data),
+      dataType: "json",
+      contentType: 'application/json',
+      success: (res) => {
+        if (res.status == 200) {
+          window.location.href = res.data;
+        }
+      },
+      error: (err) => {
+        console.log(err);
+      }
+    });
+
+    return false;
+  });
 })(jQuery)

--- a/qrcode/forms/dynamic_table.php
+++ b/qrcode/forms/dynamic_table.php
@@ -1,10 +1,23 @@
 <div class="row">
     <div class="col-12">
+        <div class="bulk-action-wrapper">
+            <form id="bulk-action" action="/bulk_action.php" method="POST"> 
+                <button type="submit" class="btn btn-primary">Bulk Action</button>
+                <select name="bulk-action">
+                    <option value="">------ Select Option -------</option>
+                    <option value="download">Download QRCode(s)</option>
+                </select>
+                <input type="hidden" name="type" value="dynamic">
+            </form>
+        </div>
+    </div>
+    <div class="col-12">
         <div class="card">
             <div class="card-body table-responsive p-0">
       <table class="table table-striped table-bordered">
         <thead>
             <tr>
+                <th width="5%"><input type="checkbox" name="bulk-select" value="1"></th>
                 <th width="5%">ID</th>
                 <th width="15%">Filename</th>
                 <th width="18%">Unique redirect identifier</th>
@@ -17,6 +30,7 @@
         <tbody>
             <?php foreach ($rows as $row): ?>
             <tr>
+                <td><input type="checkbox" name="action[]" value="<?=$row['id']?>"></td>
                 <td><?php echo $row['id']; ?></td>
                 <td><?php echo htmlspecialchars($row['filename']); ?></td>
                 <td><?php echo htmlspecialchars($row['identifier']); ?></td>
@@ -73,4 +87,16 @@
        
         </div><!-- /.Card -->
     </div><!-- /.col -->
+    <div class="col-12">
+        <div class="bulk-action-wrapper">
+            <form id="bulk-action" action="/bulk_action.php" method="POST"> 
+                <button type="submit" class="btn btn-primary">Bulk Action</button>
+                <select name="bulk-action">
+                    <option value="">------ Select Option -------</option>
+                    <option value="download">Download QRCode(s)</option>
+                </select>
+                <input type="hidden" name="type" value="dynamic">
+            </form>
+        </div>
+    </div>
 </div><!-- /.row -->

--- a/qrcode/forms/static_table.php
+++ b/qrcode/forms/static_table.php
@@ -1,10 +1,23 @@
 <div class="row">
     <div class="col-12">
+        <div class="bulk-action-wrapper">
+            <form id="bulk-action" action="/bulk_action.php" method="POST"> 
+                <button type="submit" class="btn btn-primary">Bulk Action</button>
+                <select name="bulk-action">
+                    <option value="">------ Select Option -------</option>
+                    <option value="download">Download QRCode(s)</option>
+                    <input type="hidden" name="type" value="static">
+                </select>
+            </form>
+        </div>
+    </div>
+    <div class="col-12">
         <div class="card">
             <div class="card-body table-responsive p-0">
       <table class="table table-striped table-bordered">
         <thead>
             <tr>
+                <th width="5%"><input type="checkbox" name="bulk-select" value="1"></th>
                 <th width="5%">ID</th>
                 <th width="12%">Filename</th>
                 <th width="7%">Type</th>
@@ -16,6 +29,7 @@
         <tbody>
             <?php foreach ($rows as $row): ?>
             <tr>
+                <td><input type="checkbox" name="action[]" value="<?=$row['id']?>"></td>
                 <td><?php echo $row['id']; ?></td>
                 <td><?php echo htmlspecialchars($row['filename']); ?></td>
                 <td><?php echo htmlspecialchars($row['type']); ?></td>
@@ -71,4 +85,16 @@
        
         </div><!-- /.Card -->
     </div><!-- /.col -->
+    <div class="col-12">
+        <div class="bulk-action-wrapper">
+            <form id="bulk-action" action="/bulk_action.php" method="POST"> 
+                <button type="submit" class="btn btn-primary">Bulk Action</button>
+                <select name="bulk-action">
+                    <option value="">------ Select Option -------</option>
+                    <option value="download">Download QRCode(s)</option>
+                    <input type="hidden" name="type" value="static">
+                </select>
+            </form>
+        </div>
+    </div>
 </div><!-- /.row -->

--- a/qrcode/helpers/helpers.php
+++ b/qrcode/helpers/helpers.php
@@ -116,3 +116,12 @@ function paginationLinks($current_page, $total_pages, $base_url) {
 
 	return $html;
 }
+
+function base_url(){
+    return sprintf(
+        "%s://%s:%s",
+        isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off' ? 'https' : 'http',
+        $_SERVER['SERVER_NAME'],
+        $_SERVER['SERVER_PORT']
+    );
+}

--- a/qrcode/includes/head.php
+++ b/qrcode/includes/head.php
@@ -16,3 +16,5 @@
   <link type="text/css" href="plugins/overlayScrollbars/css/OverlayScrollbars.css" rel="stylesheet"/>
   <!-- Google Font: Source Sans Pro -->
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
+  <!-- Custom Styles -->
+  <link rel="stylesheet" href="dist/css/custom.css">


### PR DESCRIPTION
This one is a bit bigger, but pretty simple.
- In both forms/dynamic_table.php and forms/static_table.php
- checkboxes to each table row, header row gets checkmark that selects all others in the table and visa-versa.
- Adds ajax to custom.js to call new backend file bulk_action.php in root folder
- bulk_action.php takes the selected qrcodes and gets their image name from the database, then creates a zip of all the images in a new folder called 'zip' that lives inside /saved_qrcode/ which use this naming convention: 
- `/zip/qrcode_{$_SESSION['user_Id']}.zip` and everytime they request a new zip, the previous one will be unlinked using this same naming convention before making a new one. as long as there's not duplicate user_id's then it shouldn't bug out.

After zip is created, returns to ajax the url where it lives, then does a redirect with javascript of that url to download it.