### PR TITLE
Feature/qrcode download as specific format [draft]

### DIFF
--- a/qrcode/bulk_action.php
+++ b/qrcode/bulk_action.php
@@ -12,15 +12,20 @@
 session_start();
 require_once 'config/config.php';
 
+use ImageConverter\ImageConverter;
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $db = getDbInstance();
     $json = json_decode(file_get_contents('php://input'), true);
     $action = filter_var($json['action'], FILTER_SANITIZE_STRING);
     $type = filter_var($json['type'], FILTER_SANITIZE_STRING);
 
-    if ($action === 'download-zip') {
+    if ($action === 'download') {
         $params = $json['params'];
         $files = [];
+
+        // Code for converting images
+        // Reference: /lib/ImageConverter/ImageConverter.php
 
         if (count($params) == 0) {
             echo json_encode([

--- a/qrcode/bulk_action.php
+++ b/qrcode/bulk_action.php
@@ -16,11 +16,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $db = getDbInstance();
     $json = json_decode(file_get_contents('php://input'), true);
     $action = filter_var($json['action'], FILTER_SANITIZE_STRING);
+    $type = filter_var($json['type'], FILTER_SANITIZE_STRING);
 
     if ($action === 'download') {
         $params = $json['params'];
         $files = [];
-        $type = filter_var($json['type'], FILTER_SANITIZE_STRING);
 
         if (count($params) == 0) {
             echo json_encode([
@@ -54,7 +54,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             'status' => 200
         ]);
         exit();
-    } 
+    }
 } else {
     exit('Direct access to this script not allowed.');
 }

--- a/qrcode/bulk_action.php
+++ b/qrcode/bulk_action.php
@@ -16,42 +16,45 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $db = getDbInstance();
     $json = json_decode(file_get_contents('php://input'), true);
     $action = filter_var($json['action'], FILTER_SANITIZE_STRING);
-    $params = $json['params'];
-    $files = [];
-    $type = filter_var($json['type'], FILTER_SANITIZE_STRING);
 
-    if (count($params) == 0) {
+    if ($action === 'download') {
+        $params = $json['params'];
+        $files = [];
+        $type = filter_var($json['type'], FILTER_SANITIZE_STRING);
+
+        if (count($params) == 0) {
+            echo json_encode([
+                'data' => 'No qrcodes were selected.',
+                'status' => 400
+            ]);
+            exit();
+        }
+
+        foreach ($params as $param) {
+            $row = $db->where('id', $param);
+            $row = $db->getOne("{$type}_qrcodes");
+            $files[] = './saved_qrcode/' . $row['qrcode'];
+        }
+
+        $zip = new ZipArchive();
+        $relative_dir = './saved_qrcode/zip/qrcodes_'. $_SESSION['user_id'] .'.zip';
+        unlink($relative_dir);
+        $url_path = base_url() . '/saved_qrcode/zip/qrcodes_'. $_SESSION['user_id'] .'.zip';
+        $zip->open($relative_dir, ZipArchive::CREATE);
+
+        foreach ($files as $file) {
+            $download_file = file_get_contents($file, true);
+            $zip->addFromString(basename($file), $download_file);
+        }
+
+        $zip->close();
+        
         echo json_encode([
-            'data' => 'No qrcodes were selected.',
-            'status' => 400
+            'data' => $url_path,
+            'status' => 200
         ]);
         exit();
-    }
-
-    foreach ($params as $param) {
-        $row = $db->where('id', $param);
-        $row = $db->getOne("{$type}_qrcodes");
-        $files[] = './saved_qrcode/' . $row['qrcode'];
-    }
-
-    $zip = new ZipArchive();
-    $relative_dir = './saved_qrcode/zip/qrcodes_'. $_SESSION['user_id'] .'.zip';
-    unlink($relative_dir);
-    $url_path = base_url() . '/saved_qrcode/zip/qrcodes_'. $_SESSION['user_id'] .'.zip';
-    $zip->open($relative_dir, ZipArchive::CREATE);
-
-    foreach ($files as $file) {
-        $download_file = file_get_contents($file, true);
-        $zip->addFromString(basename($file), $download_file);
-    }
-
-    $zip->close();
-    
-    echo json_encode([
-        'data' => $url_path,
-        'status' => 200
-    ]);
-    exit();
+    } 
 } else {
     exit('Direct access to this script not allowed.');
 }

--- a/qrcode/bulk_action.php
+++ b/qrcode/bulk_action.php
@@ -18,7 +18,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = filter_var($json['action'], FILTER_SANITIZE_STRING);
     $type = filter_var($json['type'], FILTER_SANITIZE_STRING);
 
-    if ($action === 'download') {
+    if ($action === 'download-zip') {
         $params = $json['params'];
         $files = [];
 

--- a/qrcode/dist/css/custom.css
+++ b/qrcode/dist/css/custom.css
@@ -15,3 +15,6 @@
     display: none;
     color: red;
 }
+.modal-backdrop {
+    background-color: rgba(0, 0, 0, 0.8);
+}

--- a/qrcode/dist/js/custom.js
+++ b/qrcode/dist/js/custom.js
@@ -438,7 +438,14 @@
     });
   }
 
-  const bulk_form = $('form#bulk-action');
+  const bulk_button = $('#bulk-action-button');
+
+  bulk_button.on('click', function() {
+    const bulk_select = $("select[name=bulk-action]");
+    $(`.${bulk_select.val()}-modal`).toggle();
+  });
+
+  const bulk_form = $('form#download-form');
 
   bulk_form.on('submit', function(e) {
     e.preventDefault();
@@ -455,7 +462,8 @@
     const data = {
       action: $('select[name=bulk-action]').val(),
       params: params,
-      type: $('input[name=type]').val()
+      type: $('input[name=type]').val(),
+      file_format: $('select[name=file_type]').val()
     }
 
     $.ajax({

--- a/qrcode/dynamic_qrcodes.php
+++ b/qrcode/dynamic_qrcodes.php
@@ -91,6 +91,11 @@ $total_pages = $db->totalPages;
         <!-- Table -->
         <?php include BASE_PATH . '/forms/dynamic_table.php'; ?>  
         <!-- /.Table -->
+
+        <!-- Download Modal -->
+        <?php $type = 'dynamic' ?>
+        <?php include BASE_PATH . '/forms/modals/download_qrcode.modal.php'; ?>
+        <!-- /.Download Modal -->
     
         </div><!-- /.container-fluid -->
     </section>

--- a/qrcode/forms/dynamic_table.php
+++ b/qrcode/forms/dynamic_table.php
@@ -2,14 +2,17 @@
     <div class="col-12">
         <div id="err-msg"></div>
         <div class="bulk-action-wrapper">
-            <form id="bulk-action" action="/bulk_action.php" method="POST"> 
-                <button type="submit" class="btn btn-primary">Bulk Action</button>
-                <select name="bulk-action">
-                    <option value="">------ Select Option -------</option>
-                    <option value="download-zip">Download QRCode(s) as ZIP</option>
-                </select>
-                <input type="hidden" name="type" value="dynamic">
-            </form>
+            <button id="bulk-action-button" type="button" class="btn btn-primary">
+                Bulk Action
+            </button>
+            <select name="bulk-action">
+                <option value="">
+                    ------ Select Option -------
+                </option>
+                <option value="download">
+                    Download QRCode(s)
+                </option>
+            </select> 
         </div>
     </div>
     <div class="col-12">

--- a/qrcode/forms/dynamic_table.php
+++ b/qrcode/forms/dynamic_table.php
@@ -6,7 +6,7 @@
                 <button type="submit" class="btn btn-primary">Bulk Action</button>
                 <select name="bulk-action">
                     <option value="">------ Select Option -------</option>
-                    <option value="download">Download QRCode(s)</option>
+                    <option value="download-zip">Download QRCode(s) as ZIP</option>
                 </select>
                 <input type="hidden" name="type" value="dynamic">
             </form>

--- a/qrcode/forms/modals/download_qrcode.modal.php
+++ b/qrcode/forms/modals/download_qrcode.modal.php
@@ -1,0 +1,41 @@
+<div class="modal modal-backdrop download-modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">
+                    Download QRCode(s)
+                </h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <form action="/bulk-action.php" id="download-form">
+                    <div class="form-group">
+                        <label>Select File type:</label>
+                        <select name="file_type">
+                            <option value="default" selected>
+                                Original Format(s) (default)
+                            </option>
+                            <option value="png">PNG</option>
+                            <option value="gif">GIF</option>
+                            <option value="jpeg">JPEG</option>
+                            <option value="jpg">JPG</option>
+                            <option value="svg">SVG</option>
+                            <option value="eps">EPS</option>
+                        </select>
+                        <input type="hidden" name="type" value="<?=$type?>">
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                    Close
+                </button>
+                <button type="submit" for="#download-form" class="btn btn-primary">
+                    Download
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/qrcode/forms/static_table.php
+++ b/qrcode/forms/static_table.php
@@ -6,9 +6,9 @@
                 <button type="submit" class="btn btn-primary">Bulk Action</button>
                 <select name="bulk-action">
                     <option value="">------ Select Option -------</option>
-                    <option value="download">Download QRCode(s)</option>
-                    <input type="hidden" name="type" value="static">
+                    <option value="download-zip">Download QRCode(s) as ZIP</option>
                 </select>
+                <input type="hidden" name="type" value="static">
             </form>
         </div>
     </div>

--- a/qrcode/forms/static_table.php
+++ b/qrcode/forms/static_table.php
@@ -2,14 +2,17 @@
     <div class="col-12">
         <div id="err-msg"></div>
         <div class="bulk-action-wrapper">
-            <form id="bulk-action" action="/bulk_action.php" method="POST"> 
-                <button type="submit" class="btn btn-primary">Bulk Action</button>
-                <select name="bulk-action">
-                    <option value="">------ Select Option -------</option>
-                    <option value="download-zip">Download QRCode(s) as ZIP</option>
-                </select>
-                <input type="hidden" name="type" value="static">
-            </form>
+            <button id="bulk-action-button" type="button" class="btn btn-primary">
+                Bulk Action
+            </button>
+            <select name="bulk-action">
+                <option value="">
+                    ------ Select Option -------
+                </option>
+                <option value="download">
+                    Download QRCode(s)
+                </option>
+            </select>
         </div>
     </div>
     <div class="col-12">

--- a/qrcode/helpers/helpers.php
+++ b/qrcode/helpers/helpers.php
@@ -5,6 +5,9 @@
 
 N.B. In our case the integer n is randomly chosen between a range of 5 and 8. I chose this "short" range to not overdo the length of the identifier
  */
+
+use ImageConverter\ImageConverter;
+
 function randomString($n) {
 
 	$generated_string = "";
@@ -124,4 +127,18 @@ function base_url(){
         $_SERVER['SERVER_NAME'],
         $_SERVER['SERVER_PORT']
     );
+}
+
+/**
+ * Image Converter Helper function
+ *
+ * @param string $from
+ * @param string $to
+ *
+ * @return resource
+ * @throws \InvalidArgumentException
+ */
+function convert($from, $to, $quality = null) {
+    $converter = new ImageConverter();
+    return $converter->convert($from, $to, $quality);
 }

--- a/qrcode/lib/ImageConverter/ImageConverter.php
+++ b/qrcode/lib/ImageConverter/ImageConverter.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace ImageConverter;
+
+class ImageConverter
+{
+    /** @var array */
+    private $imageFormat = [
+        'gif',
+        'jpeg',
+        'jpg',
+        'png',
+        'webp',
+    ];
+
+    /** @var array */
+    private $constImageFormat = [
+        IMAGETYPE_GIF => 'gif',
+        IMAGETYPE_JPEG => 'jpeg',
+        IMAGETYPE_PNG => 'png',
+        IMAGETYPE_WEBP => 'webp',
+    ];
+
+    /**
+     * Do image conversion work
+     *
+     * @param string $from
+     * @param string $to
+     *
+     * @return resource
+     * @throws \InvalidArgumentException
+     */
+    public function convert($from, $to, $quality = null)
+    {
+        $image = $this->loadImage($from);
+        if (!$image) {
+            throw new \InvalidArgumentException(sprintf('Cannot load image from %s', $from));
+        }
+
+        return $this->saveImage($to, $image, $quality);
+    }
+
+    private function loadImage($from)
+    {
+        $extension = $this->getRealExtension($from);
+
+        if (!array_key_exists($extension, $this->constImageFormat)) {
+            throw new \InvalidArgumentException(sprintf('The %s extension is unsupported', $extension));
+        }
+
+        $format = $this->constImageFormat[$extension];
+
+        switch ($format) {
+            case 'gif':
+                $image = imagecreatefromgif($from);
+                break;
+            case 'jpg':
+            case 'jpeg':
+                $image = imagecreatefromjpeg($from);
+                break;
+            case 'png':
+                $image = imagecreatefrompng($from);
+                break;
+            case 'webp':
+                $image = imagecreatefromwebp($from);
+                break;
+            default:
+                $image = null;
+        }
+        return $image;
+    }
+
+    private function saveImage($to, $image, $quality)
+    {
+        $extension = $this->getExtension($to);
+
+        if ($extension === 'jpg') {
+            $extension = 'jpeg';
+        }
+
+        if (!in_array($extension, $this->imageFormat)) {
+            throw new \InvalidArgumentException(sprintf('The %s extension is unsupported', $extension));
+        }
+        if (!file_exists(dirname($to))) {
+            $this->makeDirectory($to);
+        }
+
+
+        if(isset($quality) && !is_int($quality)) {
+          throw new \InvalidArgumentException(sprintf('The %s quality has to be an integer', $quality));
+        }
+
+        switch ($extension) {
+          case 'gif':
+              $image = imagegif($image, $to);
+              break;
+          case 'jpg':
+          case 'jpeg':
+              if ($quality < -1 && $quality > 100) {
+                  throw new \InvalidArgumentException(sprintf('The %s quality is out of range', $quality));
+              }
+              $image = imagejpeg($image, $to, $quality);
+              break;          
+          case 'png':
+              if ($quality < -1 && $quality > 9) {
+                  throw new \InvalidArgumentException(sprintf('The %s quality is out of range', $quality));
+              }
+              $image = imagepng($image, $to, $quality);
+              break;
+          case 'webp':
+              if ($quality < 0 || $quality > 100) {
+                  throw new \InvalidArgumentException(sprintf('The %s quality is out of range', $quality));
+              }
+              $image = imagewebp($image, $to, $quality);
+              break;
+          default:
+              $image = null;
+        }
+
+        return $image;
+    }
+
+    /**
+     * Given specific $path to detect current image extension
+     */
+    private function getRealExtension($path)
+    {
+        $extension = exif_imagetype($path);
+
+        if (!array_key_exists($extension, $this->constImageFormat)) {
+            throw new \InvalidArgumentException(sprintf('Cannot detect %s extension', $path));
+        }
+
+        return $extension;
+    }
+
+    /**
+     * Get image extension from specific $path
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    private function getExtension($path)
+    {
+        $pathInfo = pathinfo($path);
+
+        if (!array_key_exists('extension', $pathInfo)) {
+            throw new \InvalidArgumentException(sprintf('Cannot find extension from %s', $path));
+        }
+
+        return $pathInfo['extension'];
+    }
+
+    /**
+     * Try creating the directory
+     *
+     * @return bool
+     * @throws \InvalidArgumentException
+     */
+    private function makeDirectory($to)
+    {
+        $result = @mkdir(dirname($to), 0755);
+
+        if (!$result) {
+            throw new \InvalidArgumentException(\sprintf('Cannot create %s directory', $to));
+        }
+
+        return $result;
+    }
+}

--- a/qrcode/static_qrcodes.php
+++ b/qrcode/static_qrcodes.php
@@ -91,7 +91,12 @@ $total_pages = $db->totalPages;
         <!-- Table -->
         <?php include BASE_PATH . '/forms/static_table.php'; ?>  
         <!-- /.Table -->
-    
+
+        <!-- Download Modal -->
+        <?php $type = 'static' ?>
+        <?php include BASE_PATH . '/forms/modals/download_qrcode.modal.php'; ?>
+        <!-- /.Download Modal -->
+
         </div><!-- /.container-fluid -->
     </section>
   </div><!-- /.content-wrapper -->


### PR DESCRIPTION
- Adds in modal for options on file extension type
- Changes up ajax to accommodate new form instead and request will include preferred image type
- Adds in new /lib/ addition which is a class script to convert most image types - https://github.com/free-open-source/php-image-converter/blob/master/src/ImageConverter.php

To Do:
- Work with new class script to convert array of images for use in bulk_actions before zipping.
- figure out whether original gets replaced or new one gets added in. original could get replaced and the determining factor of what file extension it ends up coming out as after it's in the application is the form dropdown(s) regarding downloading/importing qrcodes.
- make form checkboxes for multiple instances of the same qrcode in the checked extensions