### PR TITLE
Fix case sensitive filename

### DIFF
--- a/src/lib/DynamicQrcode/DynamicQrcode.php
+++ b/src/lib/DynamicQrcode/DynamicQrcode.php
@@ -98,7 +98,7 @@ class DynamicQrcode {
             if(!isset($qrcode["id_owner"]))
                 $this->failure("You cannot delete this qrcode");
 
-            require_once BASE_PATH . '/lib/users/Users.php';
+            require_once BASE_PATH . '/lib/Users/Users.php';
             $users = new Users();
             $user = $users->getUser($_SESSION['user_id']);
 

--- a/src/lib/StaticQrcode/StaticQrcode.php
+++ b/src/lib/StaticQrcode/StaticQrcode.php
@@ -399,7 +399,7 @@ class StaticQrcode {
             if(!isset($qrcode["id_owner"]))
                 $this->failure("You cannot delete this qrcode");
 
-            require_once BASE_PATH . '/lib/users/Users.php';
+            require_once BASE_PATH . '/lib/Users/Users.php';
             $users = new Users();
             $user = $users->getUser($_SESSION['user_id']);
 


### PR DESCRIPTION
Would you please accept the PR?

$ grep -nr require *  | grep "lib/users/Users"
lib/DynamicQrcode/DynamicQrcode.php:101:            require_once BASE_PATH . '/lib/users/Users.php';
lib/StaticQrcode/StaticQrcode.php:402:            require_once BASE_PATH . '/lib/users/Users.php';

If not, I doubt that on case sensitive systems like Linux you will be it by require_once file not found.

Thx.
