### PR TITLE
No need to expose port on same docker network and version is obsolete

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.2"
 services:
   php-dynamic-qrcode:
     image: "giandonatoinverso/php-dynamic-qr-code:latest"
@@ -27,8 +26,6 @@ services:
     restart: "unless-stopped"
     volumes:
       - php_dynamic_qrcode_db_data:/var/lib/mysql
-    ports:
-      - '13306:3306'
     environment:
       MYSQL_ROOT_PASSWORD: "changeme"
       MYSQL_DATABASE: "qrcode"


### PR DESCRIPTION
Two fix in the PR:
- version is obsolete
- For security expose only necessary ports. No need to expose DB port on same docker network
- Thx