### PR TITLE
fix(read.php): replace deprecated FILTER_SANITIZE_STRING for PHP 8.3 …

### DIFF
--- a/src/read.php
+++ b/src/read.php
@@ -5,8 +5,9 @@ if ($_SERVER["REQUEST_METHOD"] !== "GET" || !isset($_GET['id'])) {
     die("Method not allowed. Check id parameter");
 }
 
-// Validation and sanitization of the input
-$id = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_STRING);
+// Validation and sanitization of the input UPDATE to php 8.3
+$id = filter_input(INPUT_GET, 'id', FILTER_UNSAFE_RAW);
+$id = trim(strip_tags($id));
 
 if (!$id) {
     die("Invalid ID parameter");


### PR DESCRIPTION
…compatibility

### Problem

The usage of `FILTER_SANITIZE_STRING` in `read.php` causes a deprecation warning in PHP 8.1 and breaks functionality entirely in PHP 8.3, as the constant was removed.

### Solution

This commit replaces:
```php
filter_input(INPUT_GET, 'id', FILTER_SANITIZE_STRING);



with a safer and future-proof alternative:

$id = filter_input(INPUT_GET, 'id', FILTER_UNSAFE_RAW);
$id = trim(strip_tags($id));


> _Thanks for maintaining this project! Happy to contribute._ 😊